### PR TITLE
refactor(security): switch to stateless JWT auth & optimize DB performance..

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,6 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 
 ---
 
-[![Java](https://img.shields.io/badge/Java-25-orange.svg)](https://openjdk.java.net/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Java](https://img.shields.io/badge/Java-24-orange.svg)](https://openjdk.java.net/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Build Status](https://img.shields.io/badge/Build-Passing-success.svg)]()

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	
 	<properties>
 		<java.version>25</java.version>
-		<lombok.version>1.18.38</lombok.version>
+		<lombok.version>1.18.42</lombok.version>
 		<maven.compiler.parameters>true</maven.compiler.parameters>
 	</properties>
 	<dependencies>
@@ -102,10 +102,6 @@
         	<version>0.11.5</version>
         	<scope>runtime</scope>
     	</dependency>
-    	<dependency>
-    		<groupId>com.github.ben-manes.caffeine</groupId>
-    		<artifactId>caffeine</artifactId>
-		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/yusufziyrek/blogApp/comment/application/services/CommentApplicationService.java
+++ b/src/main/java/com/yusufziyrek/blogApp/comment/application/services/CommentApplicationService.java
@@ -113,7 +113,6 @@ public class CommentApplicationService {
         response.setId(like.getId());
         response.setUserId(like.getUserId());
         response.setPostId(like.getPostId());
-        response.setCommentId(like.getCommentId());
         response.setCreatedDate(like.getCreatedDate());
         
         // Cross-module data enrichment
@@ -123,7 +122,14 @@ public class CommentApplicationService {
         } catch (Exception e) {
             response.setUserFullName("Unknown User");
         }
-        
+        if (like.getPostId() != null) {
+            try {
+                response.setPostTitle(getPostByIdUseCase.execute(like.getPostId()).getTitle());
+            } catch (Exception e) {
+                response.setPostTitle("Unknown Post");
+            }
+        }
+
         return response;
     }
 }

--- a/src/main/java/com/yusufziyrek/blogApp/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/yusufziyrek/blogApp/like/dto/response/LikeResponse.java
@@ -16,6 +16,5 @@ public class LikeResponse {
     private String userFullName;
     private Long postId;
     private String postTitle;
-    private Long commentId;
     private LocalDateTime createdDate;
 }

--- a/src/main/java/com/yusufziyrek/blogApp/post/application/services/PostApplicationService.java
+++ b/src/main/java/com/yusufziyrek/blogApp/post/application/services/PostApplicationService.java
@@ -175,8 +175,21 @@ public class PostApplicationService {
         response.setId(like.getId());
         response.setUserId(like.getUserId());
         response.setPostId(like.getPostId());
-        response.setCommentId(like.getCommentId());
         response.setCreatedDate(like.getCreatedDate());
+        try {
+            UserResponse user = getUserByIdUseCase.execute(like.getUserId());
+            response.setUserFullName(user.getFirstname() + " " + user.getLastname());
+        } catch (Exception ex) {
+            response.setUserFullName("Unknown User");
+        }
+        if (like.getPostId() != null) {
+            try {
+                PostDomain post = getPostByIdUseCase.execute(like.getPostId());
+                response.setPostTitle(post.getTitle());
+            } catch (Exception ex) {
+                response.setPostTitle("Unknown Post");
+            }
+        }
         return response;
     }
 }

--- a/src/main/java/com/yusufziyrek/blogApp/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yusufziyrek/blogApp/shared/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.yusufziyrek.blogApp.shared.security;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,13 +9,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -21,43 +24,57 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtUtil jwtUtil;
-	private final UserDetailsService userDetailsService;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
 
-		String requestURI = request.getRequestURI();
-		if (requestURI.startsWith("/api/v1/auth/refresh")) {
-			filterChain.doFilter(request, response);
-			return;
-		}
-
-		String authHeader = request.getHeader("Authorization");
-		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-			filterChain.doFilter(request, response);
-			return;
-		}
-
-		String token = authHeader.substring(7);
-
 		try {
-			String email = jwtUtil.extractEmail(token);
-			if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-				UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-				if (jwtUtil.validateToken(token)) {
-					UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-							userDetails, null, userDetails.getAuthorities());
-					SecurityContextHolder.getContext().setAuthentication(authentication);
-					log.info("UserDomain authenticated successfully: {}", email);
-				}
+			String token = extractToken(request);
+
+			if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+				// 1. Token'ı parse et ve claimleri al
+				Claims claims = jwtUtil.extractAllClaims(token);
+
+				String email = claims.getSubject();
+				Long userId = claims.get("id", Long.class);
+
+				// 2. Rolleri token'dan al
+				@SuppressWarnings("unchecked")
+				List<String> roles = (List<String>) claims.get("roles");
+
+				var authorities = (roles != null)
+						? roles.stream().map(SimpleGrantedAuthority::new).toList()
+						: List.<SimpleGrantedAuthority>of();
+
+				// 3. Kullanıcı nesnesini oluştur (Password ve Role null geçilebilir, çünkü
+				// yetkiler token'dan geldi)
+				// Username olarak email'i verdik ki loglarda null görünmesin.
+				UserDetails userDetails = new UserPrincipal(userId, email, email, null, null, true);
+
+				// 4. Context'e ata
+				UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+						userDetails, null, authorities);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
+		} catch (JwtException ex) {
+			log.warn("JWT token geçersiz veya süresi dolmuş: {}", ex.getMessage());
+			SecurityContextHolder.clearContext();
 		} catch (Exception ex) {
-			log.warn("JWT authentication failed: {}", ex.getMessage());
+			log.error("Authentication hatası", ex);
 			SecurityContextHolder.clearContext();
 		}
 
 		filterChain.doFilter(request, response);
+	}
 
+	private String extractToken(HttpServletRequest request) {
+		String header = request.getHeader("Authorization");
+		if (header != null && header.startsWith("Bearer ")) {
+			return header.substring(7);
+		}
+		return null;
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,6 @@ spring.jpa.open-in-view=false
 
 # Clean startup
 spring.output.ansi.enabled=detect
+
+# CORS Configuration
+cors.allowed-origins=http://127.0.0.1:5500,http://localhost:5500


### PR DESCRIPTION
- Remove UserDetailsService dependency from JwtAuthenticationFilter to eliminate DB lookup on every request.
- Update JwtUtil to include user roles (authorities) directly in the JWT token claims.
- Optimize token parsing logic to parse claims only once per request.
- Update AuthController (login/register/refresh) to pass authorities during token generation.
- Externalize hardcoded CORS origins to application.properties. Ref: Performance Optimization & Clean Architecture